### PR TITLE
Suggestion: define a general "invoked" event to be raised on hubs when ...

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.hubs.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.hubs.js
@@ -314,6 +314,7 @@
                 // Update the hub state
                 $.extend(proxy.state, data.State);
                 $(proxy).triggerHandler(makeEventName(eventName), [data.Args]);
+                $(proxy).triggerHandler("invoked", [[data]]);
             }
         });
 


### PR DESCRIPTION
...client-side methods are invoked by server

When client invokes non-existing server-side methods of hubs, server generates error. If client is using general proxies, he will know about that in fail() method:

proxy.invoke("send1", "Hello")    // suppose the server-side method is Send()
   .done(function() {  
      alert("Message sent");
   }).fail(function(err){
      console.log(err);   // here we can know that no 'send1' method was existed on server
   });

Also, if client uses manual proxies (using signalr.exe) than automatic proxies (<script src="/signalr/js">) and the server has changed its methods definition, client can get the error in the same fail() method.

However, when server invokes non-existing methods on client, neither the client nor the server are able to catch this incident.

In a last ditch effort we can handle "received" event for the hub connection itself to see what is coming through the connection. Although the event is raised for the whole connection not a specific proxy and the cryptic data we get in 'received' is intended for proxies, but at least it is better than nothing.

proxy.connection.received(function (data) {
   console.log(data.M);   // log the methods invoked by server
});

Now, my suggestion is, to raise a general "invoked" method on proxies whenever it receives a method invocation request from the server. This way the client will know about any methods being invoked by the server on him, no matter he has defined such a method or not. So, if the server invokes non-existing methods on a client, the client will get the error.
